### PR TITLE
fix(middleware): Remove routes before re-mounting the module

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,10 @@ const copySettingFromParent = (app, parentApp) => {
   app.set('view engine', parentApp.get('view engine'));
   app.set('views', parentApp.get('views'));
   app.set('kraken', parentApp.get('kraken'));
-  app.engines = parentApp.engines;
+
+  if(Object.keys(parentApp.engines).length) {
+    app.engines = parentApp.engines;
+  }
 }
 
 const fetchNewAppFactory = (parent, modulePath, method, config) => {

--- a/index.js
+++ b/index.js
@@ -18,11 +18,14 @@ const copySettingFromParent = (app, parentApp) => {
   app.engines = parentApp.engines;
 }
 
-const fetchNewAppFactory = (modulePath, method, config) => {
+const fetchNewAppFactory = (parent, modulePath, method, config) => {
   const newAppFactory = method ? require(modulePath)[method] : require(modulePath);
   const newAppArguments = config.arguments.length > 0 ? config.arguments[0] : {}
+  const newApp = newAppFactory(newAppArguments);
 
-  return newAppFactory(newAppArguments);
+  copySettingFromParent(newApp, parent);
+
+  return newApp;
 }
 
 module.exports = (config) => {
@@ -40,7 +43,7 @@ module.exports = (config) => {
     copySettingFromParent(app, parent);
   });
 
-  app.use(fetchNewAppFactory(finalModulePath, method, config));
+  app.use(fetchNewAppFactory(app, finalModulePath, method, config));
 
   start(directory, () => {
 
@@ -54,7 +57,6 @@ module.exports = (config) => {
 
     beforeHotReloadFn && beforeHotReloadFn();
 
-
     if (!disableAutoHotReload) {
       clearModule(finalModulePath, cachedModules);
     }
@@ -62,7 +64,7 @@ module.exports = (config) => {
     if (!disableAutoHotReload) {
       // reload the module
       app._router.stack.pop();
-      app.use(fetchNewAppFactory(finalModulePath, method, config));
+      app.use(fetchNewAppFactory(app, finalModulePath, method, config));
     }
 
     afterHotReloadFn && afterHotReloadFn();

--- a/index.js
+++ b/index.js
@@ -33,13 +33,11 @@ module.exports = (config) => {
     copySettingFromParent(app, parent);
   });
 
-  app.use((req, res, next) => {
-    const newAppFactory = method ? require(finalModulePath)[method] : require(finalModulePath);
-    const newAppArgument = config.arguments.length > 0 ? config.arguments[0] : {}
-    const newApp = newAppFactory(newAppArgument);
-    copySettingFromParent(newApp, app);
-    newApp(req, res, next);
-  });
+  const newAppFactory = method ? require(finalModulePath)[method] : require(finalModulePath);
+  const newAppArgument = config.arguments.length > 0 ? config.arguments[0] : {}
+  const newApp = newAppFactory(newAppArgument);
+
+  app.use(newApp);
 
   start(directory, () => {
 
@@ -52,6 +50,9 @@ module.exports = (config) => {
     }
 
     beforeHotReloadFn && beforeHotReloadFn();
+
+    app._router.stack.pop();
+    app.use(newApp);
 
     if (!disableAutoHotReload) {
       clearModule(finalModulePath, cachedModules);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hotware",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This prevents the routes from being continuously re-mounted.
Also, optimizing the mounting logic so that the app only gets created once on start-up, then
re-mounted on load.